### PR TITLE
unify linux and mac install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ build-backend:
 
 dist:
 	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/gimlet github.com/gimlet-io/gimlet-cli/cmd
-	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/gimlet-darwin github.com/gimlet-io/gimlet-cli/cmd
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/gimlet-linux-x86_64 github.com/gimlet-io/gimlet-cli/cmd
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/gimlet-darwin-x86_64 github.com/gimlet-io/gimlet-cli/cmd
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/gimlet-armhf github.com/gimlet-io/gimlet-cli/cmd
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/gimlet-arm64 github.com/gimlet-io/gimlet-cli/cmd
 	CGO_ENABLED=0 GOOS=windows go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/gimlet.exe github.com/gimlet-io/gimlet-cli/cmd

--- a/README.md
+++ b/README.md
@@ -6,17 +6,9 @@ For an open-source Gitops workflow.
 
 ## Installation
 
-Linux
+Linux / Mac
 ```
-curl -L https://github.com/gimlet-io/gimlet-cli/releases/download/v0.0.1/gimlet -o gimlet
-chmod +x gimlet
-sudo mv ./gimlet /usr/local/bin/gimlet
-gimlet --version
-```
-
-Mac
-```
-curl -L https://github.com/gimlet-io/gimlet-cli/releases/download/v0.0.1/gimlet -o gimlet
+curl -L https://github.com/gimlet-io/gimlet-cli/releases/download/v0.0.1/gimlet-$(uname)-$(uname -m) -o gimlet
 chmod +x gimlet
 sudo mv ./gimlet /usr/local/bin/gimlet
 gimlet --version
@@ -27,7 +19,7 @@ gimlet --version
 
 ### Configuring a Helm chart
 ```
-➜  ~ gimlet chart configure onechart/onechart                                             
+➜  ~ gimlet chart configure onechart/onechart
 👩‍💻 Configure on http://127.0.0.1:28955
 👩‍💻 Close the browser when you are done
 Browser opened


### PR DESCRIPTION
I've tested on mac and linux:

Mac:
```
$ curl -L https://github.com/lalyos/gimlet-cli/releases/download/v0.0.1/gimlet-$(uname)-$(uname -m) -o gimlet
$ chmod +x gimlet 
$ ./gimlet --version
gimlet version 0.0.1
```

Linux
```
$ docker run -it --rm cmd.cat/curl
# curl -L https://github.com/lalyos/gimlet-cli/releases/download/v0.0.1/gimlet-$(uname)-$(uname -m) -o gimlet
# chmod +x gimlet 
# ./gimlet --version
gimlet version 0.0.1
```
## notes

While testing the GH action based release process, i've realised that that the frelease has to be created manually: https://github.com/alexellis/upload-assets/issues/2

So i would suggest to use the official: actions/upload-release-asset@v1

something like: https://github.com/lalyos/jidder/blob/master/.github/workflows/release.yml 