### PR TITLE
fix ci process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2 
+      uses: actions/setup-go@v2
       with:
         go-version: 1.14.7
 
@@ -46,6 +46,14 @@ jobs:
       run: make test-backend
 
     - name: Build Backend
-      run: make build-backend
+      run: make dist
       env:
         VERSION: ${{ steps.sha_or_tag.outputs.version }}
+
+    - name: tip
+      uses: eine/tip@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        rm: true
+        files: |
+          bin/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: publish
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
   publish:
@@ -44,6 +44,17 @@ jobs:
       run: make dist
       env:
         VERSION: ${{ steps.sha_or_tag.outputs.version }}
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
 
     - name: Upload release binaries
       uses: alexellis/upload-assets@0.2.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,13 @@ jobs:
       with:
         go-version: 1.14.7
 
+    - name: Checkout main
+      uses: actions/checkout@v2
+      with:
+        ref: main
+
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         fetch-depth: 5
 
@@ -62,3 +67,14 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       with:
         asset_paths: '["./bin/gimlet*"]'
+
+    - name: Update README on main branch with new version
+      env:
+        VERSION: ${{ steps.sha_or_tag.outputs.version }}
+      run: |
+       git config --global user.email "action@github.com"
+       git config --global user.name "Github Action"
+       git checkout main
+       sed -i "s/v[0-9]\.[0-9]\.[0-9]\+/v${VERSION}/" README.md
+       git commit -am "Update README with ${VERSION}"
+       git push origin main

--- a/.github/workflows/tip.yml
+++ b/.github/workflows/tip.yml
@@ -1,15 +1,12 @@
-name: Build
+name: Tip
 on:
   push:
     branches:
-      - '*'
-  pull_request:
-    branches:
-      - '*'
+      - 'main'
 
 jobs:
   build:
-    name: Build
+    name: Tip
     runs-on: ubuntu-latest
     steps:
 
@@ -46,6 +43,14 @@ jobs:
       run: make test-backend
 
     - name: Build Backend
-      run: make build-backend
+      run: make dist
       env:
         VERSION: ${{ steps.sha_or_tag.outputs.version }}
+
+    - name: tip
+      uses: eine/tip@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        rm: true
+        files: |
+          bin/*


### PR DESCRIPTION
Two changes are proposed:

Every push triggers:
- build/generate/test/crosscompile
- upload binaries to "tip" release

Tags matching `v*` automatically creating a new release

## Tip Test

See: https://github.com/lalyos/gimlet-cli/releases/tag/tip
This provides a fix url for `nightly` build:
```
$ curl -sLo gimlet https://github.com/lalyos/gimlet-cli/releases/download/tip/gimlet-$(uname)-$(uname -m)
$ chmod +x gimlet
$ ./gimlet --version
gimlet version 8e66af7e8d8f1842412e11c7244b8d1104d2d997
```

## Release Test

The automatically create versioned release is tested with a simple:
- git tag`v0.0.2`
- git push
No manual release button push was nneded.S result ee: https://github.com/lalyos/gimlet-cli/releases/tag/v0.0.2

The release was created by octocat, not by me:
![image](https://user-images.githubusercontent.com/464122/99454209-641c3b80-2926-11eb-8d88-c0941166921c.png)

## Slow down

Please note that cross compile makes the ci process much slower. `make dist` itself takes more than 5 minutes...
Maybe the `tip` release could only contain the Linux-x86 version?